### PR TITLE
refactor: 重构search接口及集成测试

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -33,6 +33,13 @@ class ElasticsearchSettings(BaseModel):
     """Elasticsearch 相关配置"""
 
     url: str
+    number_of_shards: int
+    number_of_replicas: int
+    index_max_result_window: int
+    index_refresh_interval: str
+    index_option_type: str
+    index_option_m: int
+    index_option_ef_construction: int
     metadata_index_suffix: str
     chunk_index_suffix: str
     request_timeout: int = 15
@@ -44,7 +51,6 @@ class EmbedderSettings(BaseModel):
     model_name: str
     dimensions: int
     similarity_metric: str
-    index_type: str
 
 
 class RerankerSettings(BaseModel):
@@ -82,7 +88,14 @@ class RetrievalSettings(BaseModel):
 
     multiplier: int = Field(5, description="召回倍数配置")
     vector_weight: float = Field(2.0, description="向量搜索权重")
+    vector_similarity: float = Field(0.7, description="相似度")
     text_weight: float = Field(1.0, description="文本搜索权重")
+
+
+class SearchSettings(BaseModel):
+    """搜索相关配置"""
+
+    max_top_k: int = Field(50, description="最大top_k值限制")
 
 
 class TencentOssSettings(BaseModel):
@@ -114,6 +127,7 @@ class Settings(BaseSettings):
     storage: StorageSettings
     upload: UploadSettings
     retrieval: RetrievalSettings
+    search: SearchSettings
 
     @property
     def cos_config(self) -> CosConfig:

--- a/app/utils/converters/search.py
+++ b/app/utils/converters/search.py
@@ -58,9 +58,11 @@ class SearchConverter:
             conditions = [
                 SearchCondition(
                     field_name=cond.field,
-                    mode=SearchMode.TERM
-                    if cond.op == ConditionOperator.TERM
-                    else SearchMode.MATCH,
+                    mode=(
+                        SearchMode.TERM
+                        if cond.op == ConditionOperator.TERM
+                        else SearchMode.MATCH
+                    ),
                     value=cond.value,
                 )
                 for cond in request.query.conditions
@@ -83,7 +85,7 @@ class SearchConverter:
         if search_type == SearchType.VECTOR_HYBRID:
             results = [
                 VectorHybridSearchResult(
-                    text=doc.content.get("text", ""),
+                    text=doc.content.get("content", ""),
                     file_metadata_id=doc.content.get("file_metadata_id", ""),
                     score=doc.score,
                 )
@@ -100,4 +102,4 @@ class SearchConverter:
                 if doc.id
             ]
 
-        return SearchResponse(type=search_type, results=results)
+        return SearchResponse(results=results)

--- a/app/web/document.py
+++ b/app/web/document.py
@@ -19,6 +19,7 @@ import uuid
 from pathlib import Path
 from urllib.parse import urlparse
 
+from elasticsearch import NotFoundError
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -426,6 +427,10 @@ class DocumentHandler:
                 f"✅ 搜索完成, 返回{len(domain_response.documents)}条结果"
             )
             return resp
+        except NotFoundError as e:
+            raise HTTPException(
+                status_code=404, detail=f"索引 {request.query.index} 不存在"
+            ) from e
         except Exception as e:
             logger.error(f"❌ 搜索失败: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail="搜索处理失败") from e

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,12 @@
 elasticsearch:
   url: "http://localhost:9200"
+  number_of_shards: 1
+  number_of_replicas: 0
+  index_max_result_window: 10000
+  index_refresh_interval: 1s
+  index_option_type: "int8_hnsw"
+  index_option_m: 32 # 控制HNSW图中每个节点可以连接的最大邻居节点数量
+  index_option_ef_construction: 100 # 索引构建时每个节点考虑的候选邻居数量，影响索引质量。
   metadata_index_suffix: "_metadatas"
   chunk_index_suffix: "_chunks"
   request_timeout: 60
@@ -26,7 +33,12 @@ upload:
     - ".pdf"
     - ".md"
     - ".txt"
+
 retrieval:
   multiplier: 5        # 召回倍数配置
   vector_weight: 2.0   # 向量搜索权重
+  vector_similarity: 0.1 # 向量搜索相似度阈值
   text_weight: 1.0     # 文本搜索权重
+
+search:
+  max_top_k: 50        # 最大top_k值限制

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ API 测试配置和共享fixtures
 """
 
 import logging
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from pathlib import Path
-from typing import Any
+from typing import Any, overload
 
 import pytest
 from elasticsearch import Elasticsearch
@@ -46,6 +46,41 @@ def cos_client() -> CosS3Client:
     client.list_buckets()
     logger.info("✅ 成功连接到腾讯云COS服务。")
     return client
+
+
+@pytest.fixture(scope="class")
+def user_upload_dir() -> Path:
+    """提供 '用户准备上传' 的文件目录路径。"""
+    path = Path(__file__).parent / "fixtures" / "files" / "user"
+    path.mkdir(exist_ok=True, parents=True)
+    return path
+
+
+@pytest.fixture(scope="class")
+def get_user_upload_file(
+    user_upload_dir: Path,
+) -> Callable[[str | list[str]], Path | list[Path]]:
+    """从 'user' 目录轻松获取文件路径。"""
+
+    @overload
+    def _builder(file_names: str) -> Path: ...
+
+    @overload  # noqa: F811
+    def _builder(file_names: list[str]) -> list[Path]: ...
+
+    def _builder(file_names: str | list[str]) -> Path | list[Path]:  # noqa: F811
+        if isinstance(file_names, str):
+            path = user_upload_dir / file_names
+            if not path.exists():
+                raise FileNotFoundError(f"源文件不存在: {path}")
+            return path
+
+        paths = [user_upload_dir / name for name in file_names]
+        if not all(p.exists() for p in paths):
+            raise FileNotFoundError("一个或多个源文件不存在。")
+        return paths
+
+    return _builder  # type: ignore[return-value]
 
 
 @pytest.fixture(scope="module")

--- a/tests/fixtures/config.yaml
+++ b/tests/fixtures/config.yaml
@@ -1,5 +1,12 @@
 elasticsearch:
   url: "http://localhost:9200"
+  number_of_shards: 1
+  number_of_replicas: 0
+  index_max_result_window: 10000
+  index_refresh_interval: 1s
+  index_option_type: "int8_hnsw"
+  index_option_m: 32 # 控制HNSW图中每个节点可以连接的最大邻居节点数量
+  index_option_ef_construction: 100 # 索引构建时每个节点考虑的候选邻居数量，影响索引质量。
   metadata_index_suffix: "_metadatas"
   chunk_index_suffix: "_chunks"
   request_timeout: 15
@@ -8,7 +15,7 @@ embedder:
   model_name: "shibing624/text2vec-base-chinese"
   dimensions: 768
   similarity_metric: "cosine"
-  index_type: "int8_hnsw"
+
 
 reranker:
   model_name: "BAAI/bge-reranker-base"
@@ -30,4 +37,8 @@ upload:
 retrieval:
   multiplier: 5
   vector_weight: 2.0  # 向量搜索权重
+  vector_similarity: 0.1 # 向量搜索相似度阈值
   text_weight: 1.0    # 文本搜索权重
+
+search:
+  max_top_k: 50        # 最大top_k值限制

--- a/tests/web/document/upload_endpoint_test.py
+++ b/tests/web/document/upload_endpoint_test.py
@@ -15,7 +15,6 @@
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import overload
 
 import pytest
 from elasticsearch import Elasticsearch
@@ -33,41 +32,6 @@ class TestUploadEndpoint:
     # 数据隔离：两个接口使用不同的索引前缀
     FILE_UPLOAD_INDEX_PREFIX = "test_file_upload"
     URL_UPLOAD_INDEX_PREFIX = "test_url_upload"
-
-    @pytest.fixture(scope="class")
-    def user_upload_dir(self) -> Path:
-        """提供 '用户准备上传' 的文件目录路径。"""
-        path = (
-            Path(__file__).parent.parent.parent / "fixtures" / "files" / "user"
-        )
-        path.mkdir(exist_ok=True, parents=True)
-        return path
-
-    @pytest.fixture(scope="class")
-    def get_user_upload_file(
-        self, user_upload_dir: Path
-    ) -> Callable[[str | list[str]], Path | list[Path]]:
-        """从 'user' 目录轻松获取文件路径。"""
-
-        @overload
-        def _builder(file_names: str) -> Path: ...
-
-        @overload  # noqa: F811
-        def _builder(file_names: list[str]) -> list[Path]: ...
-
-        def _builder(file_names: str | list[str]) -> Path | list[Path]:  # noqa: F811
-            if isinstance(file_names, str):
-                path = user_upload_dir / file_names
-                if not path.exists():
-                    raise FileNotFoundError(f"源文件不存在: {path}")
-                return path
-
-            paths = [user_upload_dir / name for name in file_names]
-            if not all(p.exists() for p in paths):
-                raise FileNotFoundError("一个或多个源文件不存在。")
-            return paths
-
-        return _builder  # type: ignore[return-value]
 
     @staticmethod
     def _get_metadata_index_name(index_prefix: str) -> str:

--- a/tests/web/document/vector_hybrid_search_test.py
+++ b/tests/web/document/vector_hybrid_search_test.py
@@ -1,0 +1,414 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from collections.abc import Generator
+from pprint import pprint
+from typing import Any
+
+import pytest
+from elasticsearch import Elasticsearch
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from app.config.settings import settings
+
+
+class TestVectorHybridSearch:
+    """向量混合搜索测试
+
+    包含：
+    1. 向量混合搜索功能测试 (基于upload接口上传的数据)
+    2. 混合搜索特有参数验证测试
+    3. 错误处理和边界条件测试
+
+    使用场景：
+    - 通过upload接口上传的文档，使用search接口查询时，要用type=vector_hybrid
+    """
+
+    INDEX_PREFIX = "test_vector_hybrid_url"
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_environment(
+        self,
+        client: TestClient,
+        es_client: Elasticsearch,
+    ) -> Generator[None, Any, None]:
+        """准备测试环境（索引+数据）"""
+
+        # 1. 清理已存在的索引
+        self._cleanup_indexes(es_client, self.INDEX_PREFIX)
+
+        # 2. 准备测试数据
+        self._prepare_test_data(client, es_client, self.INDEX_PREFIX)
+
+        # 3. 执行所有测试
+        yield
+
+        # 4. 清理测试索引
+        self._cleanup_indexes(es_client, self.INDEX_PREFIX)
+
+    def _cleanup_indexes(
+        self, es_client: Elasticsearch, index_prefix: str
+    ) -> None:
+        """清理测试索引"""
+        metadata_index = self._get_metadata_index_name(index_prefix)
+        chunk_index = self._get_chunk_index_name(index_prefix)
+
+        try:
+            if es_client.indices.exists(index=metadata_index):
+                es_client.indices.delete(index=metadata_index)
+            if es_client.indices.exists(index=chunk_index):
+                es_client.indices.delete(index=chunk_index)
+        except Exception as e:
+            print(f"⚠️ 清理索引时出错: {e}")
+
+    @staticmethod
+    def _get_metadata_index_name(index_prefix: str) -> str:
+        """获取metadata索引名"""
+        return index_prefix + settings.elasticsearch.metadata_index_suffix
+
+    @staticmethod
+    def _get_chunk_index_name(index_prefix: str) -> str:
+        """获取chunk索引名"""
+        return index_prefix + settings.elasticsearch.chunk_index_suffix
+
+    def _prepare_test_data(
+        self,
+        client: TestClient,
+        es_client: Elasticsearch,
+        index_prefix: str,
+    ) -> None:
+        """准备向量混合搜索测试数据"""
+
+        print("\n🚀 开始准备向量混合搜索测试环境")
+        print(f"🔗 URL上传索引前缀: {self.INDEX_PREFIX}")
+
+        # 通过URL上传准备数据
+        self._upload_test_url(client)
+
+        # 等待数据处理完成
+        self._wait_for_test_data_ready(index_prefix, es_client)
+
+        print("✅ 向量搜索测试数据准备完成")
+
+    def _upload_test_url(self, client: TestClient) -> None:
+        """通过URL上传准备测试数据"""
+        bucket_name = settings.tencent_oss.bucket
+        cos_url = f"https://{bucket_name}.cos.{settings.tencent_oss.region}.myqcloud.com/kbase-temp/02_test.pdf"
+
+        response = client.post(
+            "/api/v1/documents/upload-from-url",
+            json={
+                "url": cos_url,
+                "index_prefix": self.INDEX_PREFIX,
+            },
+        )
+
+        assert response.status_code == 200, f"URL上传失败: {response.json()}"
+        task_id = response.json()["task_id"]
+        print(f"🔗 URL上传任务创建成功: {task_id}")
+        self._wait_for_task_completion(client, task_id)
+
+    @staticmethod
+    def _wait_for_task_completion(
+        client: TestClient, task_id: str, max_wait: int = 30
+    ) -> None:
+        """等待后台任务完成"""
+        for _ in range(max_wait):
+            response = client.get(f"/api/v1/tasks/{task_id}")
+            if response.status_code == 200:
+                status = response.json()["status"]
+                if status == "completed":
+                    return
+                elif status.startswith("failed"):
+                    pytest.fail(f"任务处理失败: {status}")
+            time.sleep(1)
+        pytest.fail(f"任务处理超时: {task_id}")
+
+    def _wait_for_test_data_ready(
+        self, index_prefix: str, es_client: Elasticsearch
+    ) -> None:
+        """等待测试数据就绪"""
+        print("⏳ 等待上传任务完成和数据索引...")
+
+        max_wait_time = 30
+        start_time = time.time()
+
+        while time.time() - start_time < max_wait_time:
+            # 检查URL上传索引
+            url_metadata_count = self._get_index_doc_count(
+                es_client, self._get_metadata_index_name(index_prefix)
+            )
+            url_chunk_count = self._get_index_doc_count(
+                es_client, self._get_chunk_index_name(index_prefix)
+            )
+
+            print(
+                f"📊 当前数据统计: URL上传(metadata: {url_metadata_count}, chunks: {url_chunk_count}) "
+            )
+
+            # 检查是否都有数据了
+            if url_metadata_count > 0 and url_chunk_count > 0:
+                print("✅ 所有上传任务完成")
+                return
+
+            time.sleep(2)
+
+        # 超时但尽量继续测试
+        print("⚠️ 等待上传超时，但继续进行测试")
+
+    @staticmethod
+    def _get_index_doc_count(es_client: Elasticsearch, index_name: str) -> int:
+        """获取索引中的文档数量"""
+        if not es_client.indices.exists(index=index_name):
+            return 0
+
+        # 刷新索引确保数据可见
+        es_client.indices.refresh(index=index_name)
+
+        try:
+            response = es_client.count(index=index_name)
+            return int(response["count"])
+        except Exception as e:
+            print(f"获取索引中文档总数失败：{e}")
+            return 0
+
+    # ===== 向量混合搜索功能测试 =====
+
+    def test_hybrid_search(self, client: TestClient) -> None:
+        """测试基础向量混合搜索 - 基于URL上传的数据"""
+        value = "统计型数据"
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "type": "vector_hybrid",
+                "query": {
+                    "index": self._get_chunk_index_name(self.INDEX_PREFIX),
+                    "conditions": [
+                        {
+                            "field": "content",
+                            "op": "match",
+                            "value": value,
+                        }
+                    ],
+                },
+                "top_k": 3,
+            },
+        )
+        pprint(f"查询字段：{value}")
+        self._assert_response(response)
+
+    @staticmethod
+    def _assert_response(response: Response) -> None:
+        assert response.status_code == 200
+        data = response.json()
+
+        # 验证响应结构
+        assert isinstance(data["results"], list)
+
+        # 验证结果格式
+        for result in data["results"]:
+            assert "text" in result  # VectorHybridSearchResult格式
+            assert "file_metadata_id" in result
+            assert "score" in result
+            assert isinstance(result["score"], int | float)
+            # 不应该包含StructuredSearchResult的字段
+            assert "id" not in result
+            assert "document" not in result
+            pprint(result)
+
+    def test_semantic_similarity(self, client: TestClient) -> None:
+        """测试语义相似性搜索"""
+        value = "用户中心并发过高"
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "type": "vector_hybrid",
+                "query": {
+                    "index": self._get_chunk_index_name(self.INDEX_PREFIX),
+                    "conditions": [
+                        {
+                            "field": "content",
+                            "op": "match",
+                            "value": value,
+                        }
+                    ],
+                },
+                "top_k": 2,
+            },
+        )
+        pprint(f"查询字段：{value}")
+        self._assert_response(response)
+
+    # ===== 参数验证测试 =====
+
+    def test_invalid_multiple_conditions(self, client: TestClient) -> None:
+        """测试向量混合搜索不允许多个条件"""
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "type": "vector_hybrid",
+                "query": {
+                    "index": self._get_chunk_index_name(self.INDEX_PREFIX),
+                    "conditions": [
+                        {"field": "content", "op": "match", "value": "Python"},
+                        {
+                            "field": "content",
+                            "op": "match",
+                            "value": "机器学习",
+                        },
+                    ],
+                },
+                "top_k": 3,
+            },
+        )
+
+        assert response.status_code == 422  # Validation error
+
+    def test_invalid_term_condition(self, client: TestClient) -> None:
+        """测试向量混合搜索不允许term操作符"""
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "type": "vector_hybrid",
+                "query": {
+                    "index": self._get_chunk_index_name(self.INDEX_PREFIX),
+                    "conditions": [
+                        {"field": "content", "op": "term", "value": "Python"}
+                    ],
+                },
+                "top_k": 3,
+            },
+        )
+
+        assert response.status_code == 422  # Validation error
+
+    def test_empty_condition_value(self, client: TestClient) -> None:
+        """测试空查询处理"""
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "type": "vector_hybrid",
+                "query": {
+                    "index": self._get_chunk_index_name(self.INDEX_PREFIX),
+                    "conditions": [
+                        {"field": "content", "op": "match", "value": ""}
+                    ],
+                },
+                "top_k": 5,
+            },
+        )
+
+        # 空查询应该返回 422 验证错误
+        assert response.status_code == 422
+
+    def test_nonexistent_index(self, client: TestClient) -> None:
+        """测试不存在的索引"""
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "type": "vector_hybrid",
+                "query": {
+                    "index": "不存在的索引_chunks",
+                    "conditions": [
+                        {"field": "content", "op": "match", "value": "测试"}
+                    ],
+                },
+                "top_k": 3,
+            },
+        )
+
+        assert response.status_code == 404
+
+    def test_search_with_filters(
+        self, es_client: Elasticsearch, client: TestClient
+    ) -> None:
+        """测试带过滤条件的向量混合搜索"""
+        value = "缓存"
+        chunk_index_number = self._get_index_doc_count(
+            es_client, self._get_chunk_index_name(self.INDEX_PREFIX)
+        )
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "type": "vector_hybrid",
+                "query": {
+                    "index": self._get_chunk_index_name(self.INDEX_PREFIX),
+                    "conditions": [
+                        {"field": "content", "op": "match", "value": value}
+                    ],
+                    "filters": {
+                        "range": {
+                            "chunk_index": {"gte": chunk_index_number - 1}
+                        }
+                    },  # 包含所有chunk
+                },
+                "top_k": 5,
+            },
+        )
+
+        pprint(f"查询字段：{value}")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data["results"], list)
+        assert len(data["results"]) == 1
+        pprint(f"{data['results']}")
+
+    def test_top_k_limit(self, client: TestClient) -> None:
+        """测试top_k参数限制"""
+        for top_k in [1, 2, 3]:
+            response = client.post(
+                "/api/v1/search",
+                json={
+                    "type": "vector_hybrid",
+                    "query": {
+                        "index": self._get_chunk_index_name(self.INDEX_PREFIX),
+                        "conditions": [
+                            {"field": "content", "op": "match", "value": "中心"}
+                        ],
+                    },
+                    "top_k": top_k,
+                },
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert isinstance(data["results"], list)
+            assert len(data["results"]) <= top_k
+            print(
+                f"📊 Top-K={top_k} 限制测试通过: 返回 {len(data['results'])} 个结果"
+            )
+
+    def test_score_ordering(self, client: TestClient) -> None:
+        """测试结果按分数排序"""
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "type": "vector_hybrid",
+                "query": {
+                    "index": self._get_chunk_index_name(self.INDEX_PREFIX),
+                    "conditions": [
+                        {"field": "content", "op": "match", "value": "缓存"}
+                    ],
+                },
+                "top_k": 3,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # 验证分数降序排列
+        scores = [result["score"] for result in data["results"]]
+        assert scores == sorted(scores, reverse=True), "结果应该按分数降序排列"
+        print(f"📊 分数排序验证通过: {scores}")


### PR DESCRIPTION
先合并 #2 再合并本pr

search接口现在已支持：
- 通过upload接口上传的“向量混合”（type=vector_hybrid)查询
- 通过save接口保存的文档的“结构化”（type=structured）查询